### PR TITLE
load legacy header

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,10 @@
   </head>
 
   <body class="h-screen justify-between flex flex-col">
-    <geor-header></geor-header>
+    <!--geor-header></geor-header-->
+    <div id="go_head">
+        <iframe src="/header/" style="width:100%;height:90px;border:none;overflow:hidden;" scrolling="no" frameborder="0"></iframe>
+    </div>
     <div class="bg-secondary/80 grow">
       <div class="container mx-auto max-w-3xl">
         <div class="my-32 mx-16">
@@ -64,7 +67,6 @@
       </ul>
     </footer>
   </body>
-  <script src="/assets/_gn-wc.js
-  "></script>
-  <script src="/assets/_header.js"></script>
+  <script src="/assets/_gn-wc.js"></script>
+  <!--script src="/assets/_header.js"></script-->
 </html>


### PR DESCRIPTION
For the 23.0 release, the [webcomponent-based header](https://github.com/georchestra/header) is not ready.

This PR provides the legacy header for the default home page:
![image](https://user-images.githubusercontent.com/265319/235479542-a8234ec8-f6e6-45ed-8ed9-1ee6e92757d1.png)

It also requires [another PR](https://github.com/georchestra/docker/pull/199) for the docker composition, since the login link on `/` is not intercepted by the security-proxy. 